### PR TITLE
feat:add support for harmony#1

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "react-native-markdown-renderer",
+  "name": "@react-native-oh-tpl/react-native-markdown-renderer",
   "version": "3.2.8",
   "description": "Markdown renderer for react-native, with CommonMark spec support + adds syntax extensions & sugar (URL autolinking, typographer).",
   "main": "src/index.js",
@@ -9,10 +9,15 @@
     "type": "git",
     "url": "git+https://github.com/mientjan/react-native-markdown-renderer.git"
   },
+  "publishConfig": { "registry": "https://registry.npmjs.org/", "access": "public" },
+  "harmony": {
+    "alias": "react-native-markdown-renderer"
+  },
   "keywords": [
     "react",
     "react-native",
     "native",
+    "harmony",
     "markdown",
     "commonmark",
     "markdown-it"
@@ -24,18 +29,17 @@
   },
   "homepage": "https://github.com/mientjan/react-native-markdown-renderer#readme",
   "dependencies": {
-    "@types/markdown-it": "^0.0.4",
-    "@types/react-native": ">=0.50.0",
-    "markdown-it": "^8.4.0",
-    "prop-types": "^15.5.10",
-    "react-native-fit-image": "^1.5.2"
+    "@types/markdown-it": "14.1.1",
+    "markdown-it": "13.0.2",
+    "prop-types": "15.8.1",
+    "react-native-fit-image": "1.5.5"
   },
   "peerDependencies": {
-    "react": "^16.2.0",
-    "react-native": "^0.50.4"
+    "react": "18.2.0",
+    "react-native": "0.72.5"
   },
   "devDependencies": {
-    "chokidar": "^2.0.0",
-    "fs-extra": "^5.0.0"
+    "chokidar": "3.6.0",
+    "fs-extra": "11.2.0"
   }
 }

--- a/src/index.js
+++ b/src/index.js
@@ -183,7 +183,7 @@ export default class Markdown extends Component {
   /**
    *
    */
-  componentWillMount() {
+  UNSAFE_componentWillMount() {
     this.updateSettings(this.props);
   }
 
@@ -191,7 +191,7 @@ export default class Markdown extends Component {
    *
    * @param nextProps
    */
-  componentWillReceiveProps(nextProps) {
+  UNSAFE_componentWillReceiveProps(nextProps) {
     this.updateSettings(nextProps);
   }
 


### PR DESCRIPTION
<!-- 感谢您提交PR！请按照模板填写，以便审阅者可以轻松理解和评估代码变更的影响。Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please follow the template so that the reviewers can easily understand what the code changes affect -->

# Summary
#1
本库是一个100%兼容CommonMark的渲染器，一个做的不错的react-native markdown渲染器。本库基于react-native-markdown-renderer[https://github.com/mientjan/react-native-markdown-renderer]的基础上,增加了对React0.72.5及react18.2.0版本的适配。
本次修改要点：
+ 适配harmony,add support for harmony
+ 适配React Native0.72.5及React18.2.0版本

## Checklist

<!-- 检查项, 请自行排查并打钩, 通过: [X] -->

- [x] 已经在真机设备或模拟器上测试通过
- [x] 已经与 Android 或 iOS 平台做过效果/功能对比
- [x] 已经添加了对应 API 的测试用例（如需要）
- [ ] 已经更新了文档（如需要）
- [ ] 更新了 JS/TS 代码 (如有)
